### PR TITLE
Name CML workers when supported

### DIFF
--- a/src/cmlextras/dask_cluster/dask_cluster.py
+++ b/src/cmlextras/dask_cluster/dask_cluster.py
@@ -39,14 +39,19 @@ class DaskCluster:
         self.dask_worker_details = None
 
     def _start_dask_scheduler(self):
-
         dask_scheduler_cmd = f"!dask scheduler --host 0.0.0.0 --dashboard-address 127.0.0.1:{self.dashboard_port}"
-        dask_scheduler = cdsw.launch_workers(
-            n=1,
-            cpu=self.scheduler_cpu,
-            memory=self.scheduler_memory,
-            code=dask_scheduler_cmd,
-        )
+
+        args = {
+            'n': 1,
+            'cpu': self.scheduler_cpu,
+            'memory': self.scheduler_memory,
+            'code': dask_scheduler_cmd,
+        }
+
+        if hasattr(cdsw.launch_workers, 'name'):
+            args['name'] = 'Dask Scheduler'
+
+        dask_scheduler = cdsw.launch_workers(**args)
 
         self.dask_scheduler_details = cdsw.await_workers(
             dask_scheduler, wait_for_completion=False, timeout_seconds=90
@@ -54,12 +59,18 @@ class DaskCluster:
 
     def _add_dask_workers(self, scheduler_addr):
         worker_start_cmd = f"!dask worker {scheduler_addr}"
-        dask_workers = cdsw.launch_workers(
-            n=self.num_workers,
-            cpu=self.worker_cpu,
-            memory=self.worker_memory,
-            code=worker_start_cmd,
-        )
+
+        args = {
+            'n': self.num_workers,
+            'cpu': self.worker_cpu,
+            'memory': self.worker_memory,
+            'code': worker_start_cmd,
+        }
+
+        if hasattr(cdsw.launch_workers, 'name'):
+            args['name'] = 'Dask Worker'
+
+        dask_workers = cdsw.launch_workers(**args)
 
         self.dask_worker_details = cdsw.await_workers(
             dask_workers, wait_for_completion=False

--- a/src/cmlextras/ray_cluster/ray_cluster.py
+++ b/src/cmlextras/ray_cluster/ray_cluster.py
@@ -32,13 +32,19 @@ class RayCluster():
 
     def _start_ray_head(self):
         # We need to start the ray process with --block else the command completes and the CML Worker terminates
-        head_start_cmd = f"!ray start --head --block --include-dashboard=true --dashboard-port={self.dashboard_port}"
-        ray_head = cdsw.launch_workers(
-            n=1,
-            cpu=self.head_cpu,
-            memory=self.head_memory,
-            code=head_start_cmd,
-        )
+        head_start_cmd = f"!ray start --head --block --disable-usage-stats --include-dashboard=true --dashboard-port={self.dashboard_port}"
+
+        args = {
+            'n': 1,
+            'cpu': self.head_cpu,
+            'memory': self.head_memory,
+            'code': head_start_cmd,
+        }
+
+        if hasattr(cdsw.launch_workers, 'name'):
+            args['name'] = 'Ray Head'
+
+        ray_head = cdsw.launch_workers(**args)
 
         self.ray_head_details = cdsw.await_workers(
           ray_head,
@@ -49,12 +55,18 @@ class RayCluster():
     def _add_ray_workers(self, head_addr):
         # We need to start the ray process with --block else the command completes and the CML Worker terminates
         worker_start_cmd = f"!ray start --block --address={head_addr}"
-        ray_workers = cdsw.launch_workers(
-            n=self.num_workers,
-            cpu=self.worker_cpu,
-            memory=self.worker_memory,
-            code=worker_start_cmd,
-        )
+
+        args = {
+            'n': self.num_workers,
+            'cpu': self.worker_cpu,
+            'memory': self.worker_memory,
+            'code': worker_start_cmd,
+        }
+
+        if hasattr(cdsw.launch_workers, 'name'):
+            args['name'] = 'Ray Worker'
+
+        ray_workers = cdsw.launch_workers(**args)
 
         self.ray_worker_details = cdsw.await_workers(
             ray_workers,


### PR DESCRIPTION
New `cdsw` library versions have the ability to name CML workers. This helps with the traceability and debuggability of the distributed CML worker infrastructure. 