### PR TITLE
added cdsw module import back into dask cluster py script

### DIFF
--- a/src/cmlextensions/dask_cluster/dask_cluster.py
+++ b/src/cmlextensions/dask_cluster/dask_cluster.py
@@ -11,6 +11,12 @@
 # use of the file.
 
 import os
+try:
+    import cml.utils_v1 as utils
+    cdsw = utils._emulate_cdsw()
+except ImportError:
+    import cdsw
+
 
 DEFAULT_DASHBOARD_PORT = os.environ["CDSW_APP_PORT"]
 


### PR DESCRIPTION
A customer is running the "test_dask_cuda_cluster.py" script and has run into "NameError: name 'cdsw' is not defined" upon initializing the Dask Cuda cluster. 

Upon further review, it seems that the cdsw module import code was somehow removed from the "das_cluster.py" script. We believe that is the cause of the error so I have opened this PR to include that back into the script. 

Please let me know if you have any questions.